### PR TITLE
Add link to randomizer website with query parameters with generated settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,10 +174,10 @@
         <p class="offOn">Default</p>
     </div>
 
-    <div class="tab">
+    <div class="tab" style="width: 300px">
         <button id="random" onclick="randomize()">Randomize</button>
-        <br />
-        <a id="randoLink" target="_blank">Link with settings</a>
+        <p><a id="randoLink" target="_blank">Link with settings</a></p>
+        <p><b>Note:</b> As the site doesn't support including experimental settings in the link, you will need to set these manually.</p>
     </div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,30 +10,30 @@
         body {
             font-family: Arial, Helvetica, sans-serif;
         }
-        
+
         .tab {
-          display: inline-table;
-          margin: 10px;
+            display: inline-table;
+            margin: 10px;
         }
     </style>
 </head>
 <body>
     <h1>2FM Rando Rando</h1>
 
-    <div class='tab'>
+    <div class="tab" id="settings">
         <h2>Settings</h2>
         <div>
             <h4>Leveling</h4>
-            <p id='level'>Default</p>
+            <p id="leveling">Default</p>
 
             <h4>Level Up Abilities</h4>
-            <p class="setting">Default</p>
+            <p class="setting" id="abilities">Default</p>
 
             <h4>Randomize Bonus Modifiers</h4>
-            <p class="offOn">Default</p>
+            <p class="offOn" id="bonusModifiers">Default</p>
 
             <h4>Randomize Stats</h4>
-            <p class="offOn">Default</p>
+            <p class="offOn" id="stats">Default</p>
 
             <h4>Randomize Keyblade Stats</h4>
             <p id="keybladeStats">Default</p>
@@ -41,140 +41,143 @@
 
         <div>
             <h4>EXP Multiplier</h4>
-            <p id="expMainMult">Default</p>
+            <p id="expMultiplier">Default</p>
 
             <h4>Valor EXP Multiplier</h4>
-            <p class="expMult">Default</p>
+            <p class="expMult" id="valorEXP">Default</p>
 
             <h4>Wisdom EXP Multiplier</h4>
-            <p class="expMult">Default</p>
+            <p class="expMult" id="wisdomEXP">Default</p>
 
             <h4>Limit EXP Multiplier</h4>
-            <p class="expMult">Default</p>
+            <p class="expMult" id="limitEXP">Default</p>
 
             <h4>Master EXP Multiplier</h4>
-            <p class="expMult">Default</p>
+            <p class="expMult" id="masterEXP">Default</p>
 
             <h4>Final EXP Multiplier</h4>
-            <p class="expMult">Default</p>
+            <p class="expMult" id="finalEXP">Default</p>
         </div>
     </div>
 
-    <div class='tab'>
+    <div class="tab" id="worlds">
         <h2>Worlds</h2>
 
         <h4>STT</h4>
-        <p class="world" id='STT'>Default</p>
+        <p class="world" id="simulatedTwilightTown">Default</p>
 
         <h4>TT</h4>
-        <p class="world" id='TT'>Default</p>
+        <p class="world" id="twilightTown">Default</p>
 
         <h4>HB</h4>
-        <p class="world" id='HB'>Default</p>
+        <p class="world" id="hollowBastion">Default</p>
 
         <h4>CoR</h4>
-        <p class="world" id='CoR'>Default</p>
+        <p class="world" id="cavernOfRemembrance">Default</p>
 
         <h4>BC</h4>
-        <p class="world" id='BC'>Default</p>
+        <p class="world" id="beastsCastle">Default</p>
 
         <h4>OC</h4>
-        <p class="world" id='OC'>Default</p>
+        <p class="world" id="olympus">Default</p>
 
         <h4>AG</h4>
-        <p class="world" id='AG'>Default</p>
+        <p class="world" id="agrabah">Default</p>
 
         <h4>LoD</h4>
-        <p class="world" id="LoD">Default</p>
+        <p class="world" id="landOfDragons">Default</p>
 
         <h4>100AW</h4>
-        <p class="world" id="AW">Default</p>
+        <p class="world" id="pooh">Default</p>
 
         <h4>AT</h4>
-        <p class="world" id="AT">Default</p>
+        <p class="world" id="atlantica">Default</p>
 
         <h4>PL</h4>
-        <p class="world" id='PL'>Default</p>
+        <p class="world" id="prideLands">Default</p>
 
         <h4>DC</h4>
-        <p class="world" id='DC'>Default</p>
+        <p class="world" id="disneyCastle">Default</p>
 
         <h4>TR</h4>
-        <p class="world" id='TR'>Default</p>
+        <p class="world" id="timelessRiver">Default</p>
 
         <h4>HT</h4>
-        <p class="world" id='HT'>Default</p>
+        <p class="world" id="halloweenTown">Default</p>
 
         <h4>PR</h4>
-        <p class="world" id='PR'>Default</p>
+        <p class="world" id="portRoyal">Default</p>
 
         <h4>SP</h4>
-        <p class="world" id='SP'>Default</p>
+        <p class="world" id="spaceParanoids">Default</p>
 
         <h4>TWTNW</h4>
-        <p class="world" id='TWTNW'>Default</p>
+        <p class="world" id="twtnw">Default</p>
     </div>
-    
-    <div class='tab'>
+
+    <div class="tab" id="include">
         <h2>Include</h2>
 
         <h4>Keyblade Abilities</h4>
-        <p id='keybladeAbilities'>Default</p>
+        <p id="keybladeAbilities">Default</p>
 
         <h4>Donald's Abilities</h4>
-        <p class='offOn'>Default</p>
+        <p class="offOn" id="donaldAbilities">Default</p>
 
         <h4>Goofy's Abilities</h4>
-        <p class='offOn'>Default</p>
+        <p class="offOn" id="goofyAbilities">Default</p>
 
         <h4>Absent Silhouettes</h4>
-        <p class='setting'>Default</p>
+        <p class="setting" id="absentSilhouettes">Default</p>
 
         <h4>Data Organization XIII</h4>
-        <p class='setting'>Default</p>
+        <p class="setting" id="dataOrganizationXIII">Default</p>
 
         <h4>Olympus Cups</h4>
-        <p class='setting'>Default</p>
+        <p class="setting" id="olympusCups">Default</p>
 
         <h4>Hades Cup</h4>
-        <p class='offOn'>Default</p>
+        <p class="offOn" id="hadesCup">Default</p>
 
         <h4>Lingering Will</h4>
-        <p class='offOn'>Default</p>
+        <p class="offOn" id="terra">Default</p>
 
         <h4>Sephiroth</h4>
-        <p class='offOn'>Default</p>
+        <p class="offOn" id="sephiroth">Default</p>
 
         <h4>Ultima Weapon</h4>
-        <p class='offOn'>Default</p>
+        <p class="offOn" id="ultimaWeapon">Default</p>
 
         <h4>Final Form</h4>
-        <p class='offOn'>Default</p>
+        <p class="offOn" id="finalForm">Default</p>
 
         <h4>Form Abilities</h4>
-        <p class='setting'>Default</p>
+        <p class="setting" id="formAbilities">Default</p>
 
         <h4>Form Growth Abilities</h4>
-        <p class='setting'>Default</p>
+        <p class="setting" id="growthAbilities">Default</p>
 
         <h4>Form MAX Growth Abilities</h4>
-        <p class='offOn'>Default</p>
+        <p class="offOn" id="maxGrowthAbilities">Default</p>
 
         <h4>Synthesis Rewards</h4>
-        <p class='offOn'>Default</p>
+        <p class="offOn" id="synthItems">Default</p>
     </div>
 
-    <div class='tab'>
+    <div class="tab">
         <h2>Experimental</h2>
 
         <h4>Randomize Bosses</h4>
-        <p class='offOn'>Default</p>
+        <p class="offOn">Default</p>
 
         <h4>Randomize Enemies</h4>
-        <p class='offOn'>Default</p>
+        <p class="offOn">Default</p>
     </div>
 
-    <button id="random" onclick="randomize()">Randomize</button>
-    
+    <div class="tab">
+        <button id="random" onclick="randomize()">Randomize</button>
+        <br />
+        <a id="randoLink" target="_blank">Link with settings</a>
+    </div>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,46 +1,107 @@
+// Polyfill for Element.closest() for IE and older browsers
+// From https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+if (!Element.prototype.matches) {
+    Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
+}
+
+if (!Element.prototype.closest) {
+    Element.prototype.closest = function (s) {
+        var el = this;
+
+        do {
+            if (Element.prototype.matches.call(el, s)) return el;
+            el = el.parentElement || el.parentNode;
+        } while (el !== null && el.nodeType === 1);
+        return null;
+    };
+}
+
+// Build settings object for use in URL params
+function setSettings(settings, item, value) {
+    var group = item.closest(".tab").id;
+    if (!group) {
+        return settings;
+    }
+
+    if (!settings.hasOwnProperty(group)) {
+        settings[group] = {};
+    }
+
+    var groupSettings = settings[group];
+    groupSettings[item.id] = value;
+
+    return settings;
+}
+
 function randomize() {
-    var mainSettings = document.getElementsByClassName('setting');
-    var offOron = document.getElementsByClassName('offOn');
-    var formMults = document.getElementsByClassName('expMult');
-    var worldSettings = document.getElementsByClassName('world');
+    var allSettings = {};
 
-    for(var i = 0; i < mainSettings.length; i++) {
-        var randomItem = settings[Math.floor(Math.random()*settings.length)];
-        mainSettings[i].innerHTML = randomItem;
+    var mainSettings = document.getElementsByClassName("setting");
+    var offOron = document.getElementsByClassName("offOn");
+    var formMults = document.getElementsByClassName("expMult");
+    var worldSettings = document.getElementsByClassName("world");
+
+    for (var i = 0; i < mainSettings.length; i++) {
+        var randomItem = Math.floor(Math.random() * settings.length);
+        mainSettings[i].innerHTML = settings[randomItem];
+        allSettings = setSettings(allSettings, mainSettings[i], randomItem);
     }
 
-    for(var i = 0; i < offOron.length; i++) {
-        var randomItem = on[Math.floor(Math.random()*on.length)];
-        offOron[i].innerHTML = randomItem;
+    for (var i = 0; i < offOron.length; i++) {
+        var randomItem = Math.floor(Math.random() * on.length);
+        offOron[i].innerHTML = on[randomItem];
+        allSettings = setSettings(allSettings, offOron[i], randomItem);
     }
 
-    for(var i = 0; i < formMults.length; i++) {
-        var randomItem = form[Math.floor(Math.random()*form.length)];
-        formMults[i].innerHTML = randomItem;
+    for (var i = 0; i < formMults.length; i++) {
+        var randomItem = Math.floor(Math.random() * form.length);
+        formMults[i].innerHTML = form[randomItem];
+        allSettings = setSettings(allSettings, formMults[i], randomItem);
     }
 
-    for(var i = 0; i < worldSettings.length; i++) {
+    for (var i = 0; i < worldSettings.length; i++) {
         worldSettings[i].innerHTML = "Randomize";
+        allSettings = setSettings(allSettings, worldSettings[i], 2);
     }
 
-    var levelSetting = leveling[Math.floor(Math.random()*leveling.length)];
-    document.getElementById('level').innerHTML = levelSetting;
+    var levelSetting = Math.floor(Math.random() * leveling.length);
+    var elem = document.getElementById("leveling");
+    elem.innerHTML = leveling[levelSetting];
+    allSettings = setSettings(allSettings, elem, levelSetting);
 
-    var keyStatSetting = keyStats[Math.floor(Math.random()*keyStats.length)];
-    document.getElementById('keybladeStats').innerHTML = keyStatSetting;
+    var keyStatSetting = Math.floor(Math.random() * keyStats.length);
+    elem = document.getElementById("keybladeStats");
+    elem.innerHTML = keyStats[keyStatSetting];
+    allSettings = setSettings(allSettings, elem, keyStatSetting);
 
-    var keyAbleSetting = keyAbilities[Math.floor(Math.random()*keyAbilities.length)];
-    document.getElementById('keybladeAbilities').innerHTML = keyAbleSetting;
+    var keyAbleSetting = Math.floor(Math.random() * keyAbilities.length);
+    elem = document.getElementById("keybladeAbilities");
+    elem.innerHTML = keyAbilities[keyAbleSetting];
+    allSettings = setSettings(allSettings, elem, keyAbleSetting);
 
-    var baseEXPSetting = exp[Math.floor(Math.random()*exp.length)];
-    document.getElementById('expMainMult').innerHTML = baseEXPSetting;
+    var baseEXPSetting = Math.floor(Math.random() * exp.length);
+    elem = document.getElementById("expMultiplier");
+    elem.innerHTML = exp[baseEXPSetting];
+    allSettings = setSettings(allSettings, elem, baseEXPSetting);
 
     worlds = shuffle(worlds);
-    
-    for(var i = 0; i < 6; i++) {
-        var randomItem = settings[Math.floor(Math.random()*settings.length)];
-        document.getElementById(worlds[i]).innerHTML = randomItem;
+
+    for (var i = 0; i < 6; i++) {
+        var randomItem = Math.floor(Math.random() * settings.length);
+        var elem = document.getElementById(worlds[i]);
+        elem.innerHTML = settings[randomItem];
+        allSettings = setSettings(allSettings, elem, randomItem);
     }
+
+    var url = "https://randomizer.valaxor.com/#/seed?";
+    for (var group in allSettings) {
+        url += group;
+        url += "=";
+        url += JSON.stringify(allSettings[group]);
+        url += "&";
+    }
+
+    document.getElementById("randoLink").setAttribute("href", url);
 }
 
 function shuffle(array) {
@@ -53,67 +114,36 @@ function shuffle(array) {
     return array;
 }
 
-var leveling = [
-    "Level 1",
-    "Level 50",
-    "Level 99"
-];
+var leveling = ["Level 1", "Level 50", "Level 99"];
 
-var settings = [
-    "Vanilla",
-    "Replace",
-    "Randomize"
-];
+var settings = ["Vanilla", "Replace", "Randomize"];
 
-var on = [
-    "Off",
-    "On"
-];
+var on = ["Off", "On"];
 
-var keyStats = [
-    "Vanilla",
-    "Balanced",
-    "Boosted"
-];
+var keyStats = ["Vanilla", "Balanced", "Boosted"];
 
-var exp = [
-    "1x",
-    "1.5x",
-    "2x",
-    "3x",
-    "5x"
-];
+var exp = ["1x", "1.5x", "2x", "3x", "5x"];
 
-var form = [
-    "1x",
-    "2x",
-    "3x",
-    "4x",
-    "5x"
-];
+var form = ["1x", "2x", "3x", "4x", "5x"];
 
-var keyAbilities = [
-    "Vanilla",
-    "Support",
-    "Action/Support"
-];
+var keyAbilities = ["Vanilla", "Support", "Action/Support"];
 
 var worlds = [
-    "STT",
-    "TT",
-    "HB",
-    "CoR",
-    "BC",
-    "OC",
-    "AG",
-    "LoD",
-    "AW",
-    "AT",
-    "PL",
-    "DC",
-    "TR",
-    "HT",
-    "PR",
-    "SP",
-    "TWTNW"
+    "simulatedTwilightTown",
+    "twilightTown",
+    "hollowBastion",
+    "cavernOfRemembrance",
+    "beastsCastle",
+    "olympus",
+    "agrabah",
+    "landOfDragons",
+    "pooh",
+    "atlantica",
+    "prideLands",
+    "disneyCastle",
+    "timelessRiver",
+    "halloweenTown",
+    "portRoyal",
+    "spaceParanoids",
+    "twtnw",
 ];


### PR DESCRIPTION
This adds a link in the generator page with query parameters in the URL containing the generated settings so that the randomizer automatically loads the settings. These are similar to the query parameters used when using the share function for a seed in the randomizer site. This avoids having to manually recreate the settings in the randomizer website. The user only needs to choose a seed name after clicking on the link. The `href` attribute is added/changed upon clicking the Randomize button.

This is done by using `id` attributes on each `p` tag for the settings, equal to the IDs for individual settings used by the randomizer, and `id` attributes on the `.tab` `div` tags for the groups. The `randomize()` function then constructs an object representing the settings using these IDs then uses this object to construct the URL.

**Note**: The link doesn't include experimental settings (i.e. Boss/Enemy Rando) as the randomizer website itself doesn't support these in shared links.